### PR TITLE
hal: ti: mspm0: fix build failure due to warnings in timer

### DIFF
--- a/source/ti/driverlib/dl_timer.c
+++ b/source/ti/driverlib/dl_timer.c
@@ -267,8 +267,8 @@ void DL_Timer_initCaptureTriggerMode(
 void DL_Timer_initCaptureCombinedMode(
     GPTIMER_Regs *gptimer, const DL_Timer_CaptureCombinedConfig *config)
 {
-    Timer_Input_Chan_Config captConfig;
-    Timer_Input_Pair_Chan_Config captPairConfig;
+    Timer_Input_Chan_Config captConfig = {0};
+    Timer_Input_Pair_Chan_Config captPairConfig = {0};
 
     DL_Timer_getInChanConfig(config->inputChan, &captConfig);
     DL_Timer_getInChanPairConfig(config->inputChan, &captPairConfig);


### PR DESCRIPTION
Zephyr RTOS twister build terminated because of compilation warnings in timer.

driverlib/dl_timer.c: In function 'DL_Timer_initCaptureCombinedMode': driverlib/dl_timer.c:290:5: error: '*(unsigned char *)(&captPairConfig +
  offsetof(Timer_Input_Pair_Chan_Config, index))' may be used uninitialized
  [-Werror=maybe-uninitialized]

  290 |     DL_Timer_setCaptureCompareCtl(gptimer, DL_TIMER_CC_MODE_CAPTURE,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  291 |         (DL_TIMER_CC_ZCOND_NONE | DL_TIMER_CC_ACOND_TIMCLK |
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  292 |             DL_TIMER_CC_LCOND_NONE | DL_TIMER_CC_CCOND_TRIG_RISE),
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  293 |         captPairConfig.index);
      |         ~~~~~~~~~~~~~~~~~~~~~
mspm0/source/ti/driverlib/dl_timer.c:271:34: note: '*(unsigned char *)(&captPairConfig
   + offsetof(Timer_Input_Pair_Chan_Config, index))' was declared here
  271 |     Timer_Input_Pair_Chan_Config captPairConfig;
      |                                  ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors